### PR TITLE
Get the posts content in index page

### DIFF
--- a/gatsby/src/components/introItem.js
+++ b/gatsby/src/components/introItem.js
@@ -1,0 +1,27 @@
+import * as React from "react";
+import * as styles from "./introItem.module.css";
+import { useStaticQuery, graphql } from "gatsby";
+
+
+const IntroItem = ({ post, kind }) => {
+    console.log(post);
+
+    return <div>
+        "title:"{post.title}
+        <br/>
+        "date:"{post.date}
+        <br/>
+        "author:"{post?.author || "AUTHOR"}
+        <br/>
+        "body id:"{post.body.data.id}
+        <br/>
+        <div dangerouslySetInnerHTML={{ __html: post.body.data.childMarkdownRemark.html }}/>
+        <br/>
+        "kind:"{kind}
+    </div>;
+};
+
+
+
+
+export default IntroItem;

--- a/gatsby/src/components/introItem.js
+++ b/gatsby/src/components/introItem.js
@@ -1,11 +1,9 @@
 import * as React from "react";
+
 import * as styles from "./introItem.module.css";
-import { useStaticQuery, graphql } from "gatsby";
 
 
 const IntroItem = ({ post, kind }) => {
-    console.log(post);
-
     return <div>
         "title:"{post.title}
         <br/>

--- a/gatsby/src/components/introItem.module.css
+++ b/gatsby/src/components/introItem.module.css
@@ -1,0 +1,7 @@
+.introItem {
+    width: 13rem;
+    height: 13rem;
+    padding: 1rem;
+    background-color: var(--color-gray);
+  }
+  

--- a/gatsby/src/pages/index.js
+++ b/gatsby/src/pages/index.js
@@ -3,21 +3,47 @@ import { Link, graphql } from "gatsby";
 
 import Layout from "../components/layout/layout";
 import Seo from "../components/seo";
+import IntroItem from "../components/introItem";
 
 const BlogIndex = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata?.title || `Title`;
   const posts = data.allStrapiPost.nodes;
+
+  // TODO: use database to find the latest post
+  // TODO: use database to random get limit posts
+  function compareDate(a, b){
+    return a.date > b.date;
+  }
+  posts.sort(compareDate);
+  // Find the newest one
+  const postNewest = posts[0];
+  // Random find another one 
+  const randonIdx = Math.round(Math.random() * (posts.length-1))
+  console.log(randonIdx)
+  const postRandom = posts[randonIdx];
+
+  //test
+  const markdowns = data.allMarkdownRemark;
+  console.log(markdowns);
+
   return (
     <Layout
       location={location}
       title={siteTitle}>
+
+      <h3>Newest Pose</h3>
+      <IntroItem post={postNewest} kind={"Big"}/>
+      <h3>Focus</h3>
+      <IntroItem post={postRandom} kind={"Small"}/>
+      <h3>Post List</h3>
       <ul>
-        { posts.map((p) => (
-          <li>
-            <Link to={p.slug}>{ p.title }</Link>
-          </li>
-        ))}
+      { posts.map((p) => (
+        <li>
+          <Link to={p.slug}>{ p.title }</Link>
+        </li>
+      ))}
       </ul>
+
     </Layout>
   );
 };
@@ -38,24 +64,23 @@ export const pageQuery = graphql`
         title
       }
     }
-    allMarkdownRemark(sort: { frontmatter: { date: DESC } }) {
-      nodes {
-        excerpt
-        fields {
-          slug
-        }
-        frontmatter {
-          date(formatString: "MMMM DD, YYYY")
-          title
-          description
-        }
-      }
-    }
     allStrapiPost {
       nodes {
         title
         slug
+        date(formatString: "MMMM DD, YYYY")
+        body{
+          data{
+            id
+            childMarkdownRemark{
+              id
+              html
+            }
+          }
+          
+        }
       }
     }
   }
 `;
+

--- a/gatsby/src/pages/index.js
+++ b/gatsby/src/pages/index.js
@@ -19,19 +19,17 @@ const BlogIndex = ({ data, location }) => {
   const postNewest = posts[0];
   // Random find another one 
   const randonIdx = Math.round(Math.random() * (posts.length-1))
-  console.log(randonIdx)
   const postRandom = posts[randonIdx];
 
   //test
   const markdowns = data.allMarkdownRemark;
-  console.log(markdowns);
 
   return (
     <Layout
       location={location}
       title={siteTitle}>
 
-      <h3>Newest Pose</h3>
+      <h3>Newest posts</h3>
       <IntroItem post={postNewest} kind={"Big"}/>
       <h3>Focus</h3>
       <IntroItem post={postRandom} kind={"Small"}/>

--- a/gatsby/yarn.lock
+++ b/gatsby/yarn.lock
@@ -1067,16 +1067,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fontsource/merriweather@^4.5.14":
-  version "4.5.14"
-  resolved "https://registry.yarnpkg.com/@fontsource/merriweather/-/merriweather-4.5.14.tgz#17b634fe3892e25f345954fe34df252730b96080"
-  integrity sha512-kDMIAokOvE9bYf+CDmEWzV3xtR8cRJlw/BipjhxqD9MIRZfU348cZ8xhHhmPXmxRiEjZLor4xxHXqps7eCvGQg==
-
-"@fontsource/montserrat@^4.5.14":
-  version "4.5.14"
-  resolved "https://registry.yarnpkg.com/@fontsource/montserrat/-/montserrat-4.5.14.tgz#5f4bfc5e7f234a986d94d9e7e7193f852e6971e3"
-  integrity sha512-fTvrteVzuFUePhr4QYBGoK8G/YHLJ3IhF1HhKg0AxcFvZajJT7rM7ULdmKLSd2PkX44R3aaFZq1zDbmjbGGI+w==
-
 "@gatsbyjs/parcel-namer-relative-to-cwd@^2.5.0":
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-2.5.0.tgz#0f8ceada6117bf9f6b5c991692ae9accb2899de7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -144,9 +144,9 @@ shebang-regex@^3.0.0:
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
 shell-quote@^1.7.3:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.4.tgz#33fe15dee71ab2a81fcbd3a52106c5cfb9fb75d8"
-  integrity sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.0.tgz#20d078d0eaf71d54f43bd2ba14a1b5b9bfa5c8ba"
+  integrity sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ==
 
 spawn-command@^0.0.2-1:
   version "0.0.2-1"


### PR DESCRIPTION
<!-- 
Remove non-applicable sections/bullet points to keep the git message short. 
-->

# Purpose

<!-- Describe the purpose of this change in a few sentences. -->
Design the homepage, add fake posts to help organize the page, display all the posts' details to help on designing.

## Type of change

<!-- Delete irrelevant options. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Requires documentation update

## Root Causes

<!-- For bug fixes, describe the root causes of the issue(s) addressed in this pull request. -->

# Solution

<!-- Describe the solution implemented in this pull request. -->
In the homepage, I design we have two parts, one shows up the latest post, another shows some random posts.
In this PR, I modified the query in index.js to get the markdown and Id back. Homepage can successfully show up one latest post and one random post. And all the details of post are displayed right now, include the markdown in html format. 

# Tests

- [ ] I have added automatic unit tests for this change.
- [ ] This change requires manual testing, details are below.

## Manual Tests

<!-- Describe the tests you performed to verify the correctness of this change. Provide instructions so that the reviewer can reproduce the tests. Include any relevant details about your test configuration. -->

- [x] Test A
I added two posts in my dataset. In the homepage, the latest post and random post are successfully displayed.
![image](https://user-images.githubusercontent.com/8042791/218295800-d3f13d42-886f-481e-afff-6fcc9b8096bc.png)
![image](https://user-images.githubusercontent.com/8042791/218295836-a807c95f-4059-4c53-bae7-a04bbcaebc99.png)

- [ ] Test B
